### PR TITLE
[codex] wire ai_picture to shared model config

### DIFF
--- a/bonus/ai_picture.py
+++ b/bonus/ai_picture.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import io
-import os
+import json
 import re
 from pathlib import Path
 from urllib.parse import quote
 
 import requests
+from shared.ai_config import get_openai_api_key, get_openai_base_url, get_openai_model
 
 try:
     from PIL import Image, ImageTk
@@ -31,6 +32,53 @@ REQUEST_TIMEOUT = 60
 
 class AIPictureError(Exception):
     """Raised when AI picture generation fails."""
+
+def _build_image_prompt_with_llm(prompt: str) -> str:
+    """Use the configured LLM to turn a user request into a concise image prompt."""
+
+    system_prompt = (
+        "You write production-ready prompts for text-to-image models. "
+        "Return one concise visual prompt only. "
+        "Do not add markdown, labels, explanations, or quotation marks."
+    )
+    payload = {
+        "model": get_openai_model(),
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": (
+                    "Rewrite this into a vivid image-generation prompt with subject, style, "
+                    "lighting, composition, and quality hints when useful. "
+                    f"User request: {prompt}"
+                ),
+            },
+        ],
+        "temperature": 0.4,
+    }
+
+    try:
+        response = requests.post(
+            f"{get_openai_base_url()}/chat/completions",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {get_openai_api_key()}",
+            },
+            data=json.dumps(payload),
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise AIPictureError(f"Prompt model request failed: {exc}") from exc
+
+    try:
+        content = response.json()["choices"][0]["message"]["content"].strip()
+    except (ValueError, KeyError, IndexError, TypeError) as exc:
+        raise AIPictureError("Prompt model returned an unexpected response.") from exc
+
+    if not content:
+        raise AIPictureError("Prompt model returned an empty prompt.")
+    return content
 
 
 def parse_aipic_prompt(message: str) -> str | None:
@@ -64,13 +112,15 @@ def _ensure_unique_path(folder: Path, stem: str) -> Path:
 
 def generate_image(prompt: str, output_root: Path | None = None) -> str:
     """
-    Generate image via Pollinations.ai and save under generated_images/.
+    Generate image using the configured LLM for prompt writing and Pollinations for rendering.
 
     Returns a relative path like 'generated_images/example.png'.
     """
     cleaned_prompt = prompt.strip()
     if not cleaned_prompt:
         raise AIPictureError("Empty image prompt.")
+
+    rendered_prompt = _build_image_prompt_with_llm(cleaned_prompt)
 
     root = output_root if output_root is not None else Path.cwd()
     output_dir = root / OUTPUT_DIR_NAME
@@ -79,7 +129,7 @@ def generate_image(prompt: str, output_root: Path | None = None) -> str:
 
     try:
         response = requests.get(
-            f"{POLLINATIONS_URL}/{quote(cleaned_prompt)}",
+            f"{POLLINATIONS_URL}/{quote(rendered_prompt)}",
             params={"model": "flux", "width": 768, "height": 768},
             timeout=REQUEST_TIMEOUT,
         )

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers used across project modules."""

--- a/shared/ai_config.py
+++ b/shared/ai_config.py
@@ -1,0 +1,32 @@
+"""Shared configuration for OpenAI-compatible model access."""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
+DEFAULT_OPENAI_BASE_URL = "https://yinli.one"
+DEFAULT_OPENAI_MODEL = "claude-sonnet-4-6"
+
+
+def normalize_openai_base_url(base_url: str) -> str:
+    """Normalize an OpenAI-compatible base URL to include the /v1 prefix."""
+
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized
+    return f"{normalized}/v1"
+
+
+def get_openai_api_key() -> str:
+    return os.getenv("OPENAI_API_KEY", DEFAULT_OPENAI_API_KEY).strip()
+
+
+def get_openai_base_url() -> str:
+    return normalize_openai_base_url(
+        os.getenv("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL).strip()
+    )
+
+
+def get_openai_model() -> str:
+    return os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL).strip()


### PR DESCRIPTION
## What changed
- updated `bonus/ai_picture.py` to rewrite `/aipic` user prompts through the configured OpenAI-compatible chat model before sending them to Pollinations for rendering
- added `shared/ai_config.py` and `shared/__init__.py` so model base URL, model id, and API key lookup live in one shared module
- replaced the repo default API key with the placeholder `YOUR_OPENAI_API_KEY`

## Why
The image helper needed to use the new model gateway without committing a real credential into the repository.

## Impact
Users can keep the existing image rendering flow, but prompts are now improved by the configured chat model first. Deployments must provide `OPENAI_API_KEY` at runtime.

## Validation
- `python3 -m py_compile shared/ai_config.py bonus/ai_picture.py`
- `OPENAI_API_KEY=... python3 - <<'PY' ... _build_image_prompt_with_llm('a minimal line-art fox logo') ... PY`
