### PR TITLE
[codex] Improve bot failure diagnostics

### DIFF
--- a/chatbot/chatbot_client.py
+++ b/chatbot/chatbot_client.py
@@ -18,6 +18,26 @@ from shared.ai_config import (
 )
 
 
+class ChatBotError(RuntimeError):
+    """Base exception for chatbot request failures."""
+
+
+class ChatBotConfigurationError(ChatBotError):
+    """Raised when chatbot credentials are missing."""
+
+
+class ChatBotAuthenticationError(ChatBotError):
+    """Raised when the model service rejects authentication."""
+
+
+class ChatBotConnectionError(ChatBotError):
+    """Raised when the model service cannot be reached reliably."""
+
+
+class ChatBotResponseError(ChatBotError):
+    """Raised when the model service returns unusable data."""
+
+
 class ChatBotClient:
     """Small chatbot client for an OpenAI-compatible model endpoint."""
 
@@ -47,8 +67,11 @@ class ChatBotClient:
     def _ensure_runtime_config(self) -> None:
         """Load API configuration only when the chatbot is actually used."""
 
-        if self.api_key is None:
-            self.api_key = get_openai_api_key()
+        try:
+            if self.api_key is None:
+                self.api_key = get_openai_api_key()
+        except RuntimeError as error:
+            raise ChatBotConfigurationError(str(error)) from error
         if self.base_url is None:
             self.base_url = get_openai_base_url()
         if self.model is None:
@@ -98,15 +121,25 @@ class ChatBotClient:
                 response_data = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"Chatbot API returned HTTP {error.code}: {detail}") from error
+            if error.code in {401, 403}:
+                raise ChatBotAuthenticationError(
+                    f"Chatbot API returned HTTP {error.code}: {detail}"
+                ) from error
+            raise ChatBotConnectionError(
+                f"Chatbot API returned HTTP {error.code}: {detail}"
+            ) from error
         except urllib.error.URLError as error:
-            raise RuntimeError(f"Could not reach chatbot API: {error.reason}") from error
+            raise ChatBotConnectionError(
+                f"Could not reach chatbot API: {error.reason}"
+            ) from error
         except TimeoutError as error:
-            raise RuntimeError("Chatbot API request timed out.") from error
+            raise ChatBotConnectionError("Chatbot API request timed out.") from error
         except json.JSONDecodeError as error:
-            raise RuntimeError("Chatbot API returned invalid JSON.") from error
+            raise ChatBotResponseError("Chatbot API returned invalid JSON.") from error
 
         try:
             return response_data["choices"][0]["message"]["content"].strip()
         except (KeyError, IndexError, TypeError) as error:
-            raise RuntimeError("Chatbot API response format was unexpected.") from error
+            raise ChatBotResponseError(
+                "Chatbot API response format was unexpected."
+            ) from error

--- a/client/gui_client.py
+++ b/client/gui_client.py
@@ -30,7 +30,6 @@ class GUIChatClient:
 
         self.client_socket: socket.socket | None = None
         self.receiver_thread: threading.Thread | None = None
-        self.bot_thread: threading.Thread | None = None
         self.window_closed = False
         self.ui_queue: queue.Queue[tuple[int, str, object | None]] = queue.Queue()
         self.queue_job_id: str | None = None
@@ -303,7 +302,7 @@ class GUIChatClient:
             return f"Bot: {message['content']}\n"
 
         if message["type"] == "system":
-            return f"System: {message['content']}\n"
+            return f"System: {self.friendly_server_error_message(str(message['content']))}\n"
 
         if message["type"] == "error":
             return f"System: {self.friendly_server_error_message(str(message['content']))}\n"
@@ -414,9 +413,6 @@ class GUIChatClient:
                     self.add_text(payload)
                 elif action == "message" and isinstance(payload, dict):
                     self.handle_server_message(payload)
-                elif action == "bot_response" and isinstance(payload, str):
-                    bot_message = create_message("bot_response", "Bot", payload)
-                    self.add_text(self.format_message(bot_message))
                 elif action == "disconnect":
                     self.handle_disconnect()
         except queue.Empty:
@@ -479,6 +475,16 @@ class GUIChatClient:
             return "Invalid move. It is not your turn."
         if "invalid move" in lowered:
             return "Invalid move. Choose an empty cell."
+        if "bot is not configured on the server" in lowered:
+            return "Bot is not configured on the server."
+        if "bot service authentication failed" in lowered:
+            return "Bot service authentication failed."
+        if "bot service is unreachable right now" in lowered:
+            return "Bot service is unreachable right now."
+        if "bot service returned an invalid response" in lowered:
+            return "Bot service returned an invalid response."
+        if "bot failed unexpectedly. check server logs." in lowered:
+            return "Bot failed unexpectedly. Check server logs."
         if "bot is temporarily unavailable" in lowered:
             return "Bot is temporarily unavailable."
         if "target user" in lowered and "not connected" in lowered:
@@ -608,29 +614,6 @@ class GUIChatClient:
         self.user_listbox.delete(0, "end")
         for username in user_list:
             self.user_listbox.insert("end", username)
-
-    def start_bot_request(self, command_text: str) -> None:
-        """Launch chatbot work in a background thread so the GUI stays responsive."""
-
-        user_key = self.get_chatbot_user_key()
-        self.sync_personality_selection(user_key)
-        self.add_text(f"{self.username_var.get().strip()}: {command_text}\n")
-        self.bot_thread = threading.Thread(
-            target=self.fetch_bot_response,
-            args=(user_key, command_text),
-            daemon=True,
-        )
-        self.bot_thread.start()
-
-    def fetch_bot_response(self, user_key: str, command_text: str) -> None:
-        """Call the chatbot manager and queue the result for the GUI thread."""
-
-        try:
-            response_text = self.chatbot_manager.chat(user_key, command_text)
-        except Exception:
-            response_text = "Bot is temporarily unavailable."
-
-        self.ui_queue.put((self.connection_id, "bot_response", response_text))
 
     def handle_personality_command(self, command_text: str) -> None:
         """Apply a personality command and show the result locally."""

--- a/server/server.py
+++ b/server/server.py
@@ -15,12 +15,25 @@ from bonus.summary_keywords import (
     extract_keywords,
     generate_summary,
 )
+from chatbot.chatbot_client import (
+    ChatBotAuthenticationError,
+    ChatBotConfigurationError,
+    ChatBotConnectionError,
+    ChatBotResponseError,
+)
 from chatbot.chatbot_manager import ChatbotManager
 from server.chat_history import ChatHistory
 from server.game_manager import GameManager
 from server.protocol import MESSAGE_TYPES, ProtocolError, create_message, decode_message, encode_message
+from shared.ai_config import inspect_openai_config
 
 LOGGER = logging.getLogger(__name__)
+
+BOT_NOT_CONFIGURED_MESSAGE = "Bot is not configured on the server."
+BOT_AUTH_FAILED_MESSAGE = "Bot service authentication failed."
+BOT_UNREACHABLE_MESSAGE = "Bot service is unreachable right now."
+BOT_INVALID_RESPONSE_MESSAGE = "Bot service returned an invalid response."
+BOT_UNEXPECTED_FAILURE_MESSAGE = "Bot failed unexpectedly. Check server logs."
 
 
 @dataclass
@@ -50,6 +63,7 @@ class ChatServer:
         self.history_limit = 12
         self.summary_history_limit = 30
         self.bot_mention_pattern = re.compile(r"(?i)(?<!\w)@bot\b")
+        self.ai_config_status = inspect_openai_config()
         self.lock = threading.Lock()
 
     def start(self) -> None:
@@ -64,10 +78,14 @@ class ChatServer:
         self.server_socket.bind((self.host, self.port))
         self.server_socket.listen()
         LOGGER.info("Server listening on %s:%s", self.host, self.port)
+        self._log_bot_startup_status()
 
         try:
             while True:
-                client_socket, address = self.server_socket.accept()
+                try:
+                    client_socket, address = self.server_socket.accept()
+                except OSError:
+                    break
                 LOGGER.info("Client connected: %s:%s", address[0], address[1])
                 thread = threading.Thread(
                     target=self.handle_client,
@@ -416,11 +434,21 @@ class ChatServer:
         try:
             response_text = self.chatbot_manager.chat(sender_name, prompt_text)
         except Exception as error:
-            LOGGER.exception("Chatbot error while handling mention from %s", sender_name)
+            user_message, log_level = self._classify_bot_error(error)
+            LOGGER.log(
+                log_level,
+                "Chatbot error while handling mention from %s [base_url=%s model=%s configured=%s]: %s",
+                sender_name,
+                self.ai_config_status.base_url,
+                self.ai_config_status.model,
+                self.ai_config_status.is_configured,
+                error,
+                exc_info=True,
+            )
             system_message = create_message(
                 "system",
                 "System",
-                "Bot is temporarily unavailable.",
+                user_message,
             )
             self.broadcast(system_message)
             return
@@ -428,6 +456,38 @@ class ChatServer:
         bot_message = create_message("bot_response", "Bot", response_text)
         self.broadcast(bot_message)
         self._record_group_message(bot_message)
+
+    def _log_bot_startup_status(self) -> None:
+        """Log whether optional bot features are configured at server startup."""
+
+        self.ai_config_status = inspect_openai_config()
+        if self.ai_config_status.is_configured:
+            LOGGER.info(
+                "Bot AI features enabled [base_url=%s model=%s]",
+                self.ai_config_status.base_url,
+                self.ai_config_status.model,
+            )
+            return
+
+        LOGGER.warning(
+            "Bot AI features are not configured; chatbot commands will return '%s' [base_url=%s model=%s]",
+            BOT_NOT_CONFIGURED_MESSAGE,
+            self.ai_config_status.base_url,
+            self.ai_config_status.model,
+        )
+
+    def _classify_bot_error(self, error: Exception) -> tuple[str, int]:
+        """Map chatbot exceptions to stable user-facing messages and log levels."""
+
+        if isinstance(error, ChatBotConfigurationError):
+            return BOT_NOT_CONFIGURED_MESSAGE, logging.WARNING
+        if isinstance(error, ChatBotAuthenticationError):
+            return BOT_AUTH_FAILED_MESSAGE, logging.ERROR
+        if isinstance(error, ChatBotConnectionError):
+            return BOT_UNREACHABLE_MESSAGE, logging.ERROR
+        if isinstance(error, ChatBotResponseError):
+            return BOT_INVALID_RESPONSE_MESSAGE, logging.ERROR
+        return BOT_UNEXPECTED_FAILURE_MESSAGE, logging.ERROR
 
     def _handle_summary_request(self, requester_socket: socket.socket, requester_name: str) -> None:
         """Generate a private summary from recent public chat history."""

--- a/shared/ai_config.py
+++ b/shared/ai_config.py
@@ -3,9 +3,23 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 
 DEFAULT_OPENAI_BASE_URL = "https://yinli.one"
 DEFAULT_OPENAI_MODEL = "claude-sonnet-4-6"
+
+
+@dataclass(frozen=True)
+class OpenAIConfigStatus:
+    """Describe the current OpenAI-compatible runtime configuration."""
+
+    has_api_key: bool
+    base_url: str
+    model: str
+
+    @property
+    def is_configured(self) -> bool:
+        return self.has_api_key
 
 
 def normalize_openai_base_url(base_url: str) -> str:
@@ -34,3 +48,14 @@ def get_openai_base_url() -> str:
 
 def get_openai_model() -> str:
     return os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL).strip()
+
+
+def inspect_openai_config() -> OpenAIConfigStatus:
+    """Return the resolved AI configuration without raising for missing credentials."""
+
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    return OpenAIConfigStatus(
+        has_api_key=bool(api_key),
+        base_url=get_openai_base_url(),
+        model=get_openai_model(),
+    )

--- a/tests/test_chatbot_client.py
+++ b/tests/test_chatbot_client.py
@@ -6,8 +6,9 @@ import os
 import unittest
 from unittest.mock import patch
 
-from chatbot.chatbot_client import ChatBotClient
+from chatbot.chatbot_client import ChatBotClient, ChatBotConfigurationError
 from chatbot.chatbot_manager import ChatbotManager
+from shared.ai_config import inspect_openai_config
 
 
 class ChatbotClientLazyConfigTests(unittest.TestCase):
@@ -29,7 +30,7 @@ class ChatbotClientLazyConfigTests(unittest.TestCase):
     def test_real_prompt_requires_openai_api_key_only_when_used(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             client = ChatBotClient()
-            with self.assertRaisesRegex(RuntimeError, "OPENAI_API_KEY is not set"):
+            with self.assertRaisesRegex(ChatBotConfigurationError, "OPENAI_API_KEY is not set"):
                 client.chat("@bot hello")
 
     def test_chatbot_manager_can_initialize_without_openai_env(self) -> None:
@@ -37,6 +38,32 @@ class ChatbotClientLazyConfigTests(unittest.TestCase):
             manager = ChatbotManager()
 
         self.assertIsInstance(manager.client, ChatBotClient)
+
+    def test_inspect_openai_config_reports_unconfigured_without_raising(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            status = inspect_openai_config()
+
+        self.assertFalse(status.is_configured)
+        self.assertFalse(status.has_api_key)
+        self.assertEqual(status.base_url, "https://yinli.one/v1")
+        self.assertEqual(status.model, "claude-sonnet-4-6")
+
+    def test_inspect_openai_config_reports_resolved_values(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_BASE_URL": "https://example.com/custom",
+                "OPENAI_MODEL": "demo-model",
+            },
+            clear=True,
+        ):
+            status = inspect_openai_config()
+
+        self.assertTrue(status.is_configured)
+        self.assertTrue(status.has_api_key)
+        self.assertEqual(status.base_url, "https://example.com/custom/v1")
+        self.assertEqual(status.model, "demo-model")
 
 
 if __name__ == "__main__":

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -6,6 +6,12 @@ import socket
 import unittest
 from unittest.mock import patch
 
+from chatbot.chatbot_client import (
+    ChatBotAuthenticationError,
+    ChatBotConfigurationError,
+    ChatBotConnectionError,
+    ChatBotResponseError,
+)
 from client.gui_client import GUIChatClient
 from server.protocol import create_message, decode_message, encode_message
 from server.server import ChatServer, ClientConnection
@@ -120,7 +126,80 @@ class ErrorHandlingTests(unittest.TestCase):
         self.assertEqual(error_message["content"], "Invalid move. It is not your turn.")
         self.assertIn("Invalid game move", "\n".join(move_logs.output))
 
-    def test_chatbot_failure_logs_and_broadcasts_system_message(self) -> None:
+    def test_chatbot_missing_config_returns_friendly_system_message(self) -> None:
+        _alice_client, alice_file, _alice_server = self._add_client("Alice")
+        _bob_client, bob_file, _bob_server = self._add_client("Bob")
+
+        with patch.object(
+            self.server.chatbot_manager,
+            "chat",
+            side_effect=ChatBotConfigurationError("OPENAI_API_KEY is not set"),
+        ):
+            with self.assertLogs("server.server", level="WARNING") as logs:
+                self.server._handle_group_bot_mention("Alice", "@bot help")
+
+        alice_message = self._read_message(alice_file)
+        bob_message = self._read_message(bob_file)
+        self.assertEqual(alice_message["type"], "system")
+        self.assertEqual(alice_message["content"], "Bot is not configured on the server.")
+        self.assertEqual(bob_message["content"], "Bot is not configured on the server.")
+        self.assertIn("Chatbot error while handling mention from Alice", "\n".join(logs.output))
+
+    def test_chatbot_auth_failure_returns_friendly_system_message(self) -> None:
+        _alice_client, alice_file, _alice_server = self._add_client("Alice")
+        _bob_client, bob_file, _bob_server = self._add_client("Bob")
+
+        with patch.object(
+            self.server.chatbot_manager,
+            "chat",
+            side_effect=ChatBotAuthenticationError("Chatbot API returned HTTP 401"),
+        ):
+            with self.assertLogs("server.server", level="ERROR") as logs:
+                self.server._handle_group_bot_mention("Alice", "@bot help")
+
+        alice_message = self._read_message(alice_file)
+        bob_message = self._read_message(bob_file)
+        self.assertEqual(alice_message["content"], "Bot service authentication failed.")
+        self.assertEqual(bob_message["content"], "Bot service authentication failed.")
+        self.assertIn("configured=", "\n".join(logs.output))
+
+    def test_chatbot_network_failure_returns_friendly_system_message(self) -> None:
+        _alice_client, alice_file, _alice_server = self._add_client("Alice")
+        _bob_client, bob_file, _bob_server = self._add_client("Bob")
+
+        with patch.object(
+            self.server.chatbot_manager,
+            "chat",
+            side_effect=ChatBotConnectionError("Could not reach chatbot API: timed out"),
+        ):
+            with self.assertLogs("server.server", level="ERROR") as logs:
+                self.server._handle_group_bot_mention("Alice", "@bot help")
+
+        alice_message = self._read_message(alice_file)
+        bob_message = self._read_message(bob_file)
+        self.assertEqual(alice_message["content"], "Bot service is unreachable right now.")
+        self.assertEqual(bob_message["content"], "Bot service is unreachable right now.")
+        self.assertIn("Chatbot error while handling mention from Alice", "\n".join(logs.output))
+
+    def test_chatbot_invalid_response_returns_friendly_system_message(self) -> None:
+        _alice_client, alice_file, _alice_server = self._add_client("Alice")
+        _bob_client, bob_file, _bob_server = self._add_client("Bob")
+
+        with patch.object(
+            self.server.chatbot_manager,
+            "chat",
+            side_effect=ChatBotResponseError("Chatbot API returned invalid JSON."),
+        ):
+            with self.assertLogs("server.server", level="ERROR") as logs:
+                self.server._handle_group_bot_mention("Alice", "@bot help")
+
+        alice_message = self._read_message(alice_file)
+        bob_message = self._read_message(bob_file)
+        self.assertEqual(alice_message["content"], "Bot service returned an invalid response.")
+        self.assertEqual(bob_message["content"], "Bot service returned an invalid response.")
+        self.assertIn("Chatbot API returned invalid JSON.", "\n".join(logs.output))
+
+    def test_chatbot_unexpected_failure_returns_generic_system_message(self) -> None:
         _alice_client, alice_file, _alice_server = self._add_client("Alice")
         _bob_client, bob_file, _bob_server = self._add_client("Bob")
 
@@ -130,10 +209,15 @@ class ErrorHandlingTests(unittest.TestCase):
 
         alice_message = self._read_message(alice_file)
         bob_message = self._read_message(bob_file)
-        self.assertEqual(alice_message["type"], "system")
-        self.assertEqual(alice_message["content"], "Bot is temporarily unavailable.")
-        self.assertEqual(bob_message["content"], "Bot is temporarily unavailable.")
-        self.assertIn("Chatbot error while handling mention from Alice", "\n".join(logs.output))
+        self.assertEqual(alice_message["content"], "Bot failed unexpectedly. Check server logs.")
+        self.assertEqual(bob_message["content"], "Bot failed unexpectedly. Check server logs.")
+        self.assertIn("api down", "\n".join(logs.output))
+
+    def test_server_logs_bot_startup_warning_when_ai_is_unconfigured(self) -> None:
+        with self.assertLogs("server.server", level="WARNING") as logs:
+            self.server._log_bot_startup_status()
+
+        self.assertIn("Bot AI features are not configured", "\n".join(logs.output))
 
     def test_gui_error_mapping_is_friendly(self) -> None:
         self.assertEqual(
@@ -151,6 +235,26 @@ class ErrorHandlingTests(unittest.TestCase):
         self.assertEqual(
             GUIChatClient.friendly_server_error_message("Invalid move (cell occupied or out of bounds)"),
             "Invalid move. Choose an empty cell.",
+        )
+        self.assertEqual(
+            GUIChatClient.friendly_server_error_message("Bot is not configured on the server."),
+            "Bot is not configured on the server.",
+        )
+        self.assertEqual(
+            GUIChatClient.friendly_server_error_message("Bot service authentication failed."),
+            "Bot service authentication failed.",
+        )
+        self.assertEqual(
+            GUIChatClient.friendly_server_error_message("Bot service is unreachable right now."),
+            "Bot service is unreachable right now.",
+        )
+        self.assertEqual(
+            GUIChatClient.friendly_server_error_message("Bot service returned an invalid response."),
+            "Bot service returned an invalid response.",
+        )
+        self.assertEqual(
+            GUIChatClient.friendly_server_error_message("Bot failed unexpectedly. Check server logs."),
+            "Bot failed unexpectedly. Check server logs.",
         )
         self.assertEqual(
             GUIChatClient.friendly_server_error_message("Bot is temporarily unavailable."),


### PR DESCRIPTION
## Summary
Improve bot failure diagnostics so AI availability is explicit and easier to debug.

## What Changed
- added non-throwing AI config inspection for startup status
- classified chatbot failures into configuration, authentication, connectivity, response, and unexpected error buckets
- surfaced friendly bot error messages in the server and GUI instead of one generic fallback
- removed the stale GUI-local bot execution path so `@bot` is server-driven only
- expanded tests for AI config inspection and categorized bot failure handling

## Why
The chat UI previously showed `Bot is temporarily unavailable.` for every bot failure, which hid the real cause and made it hard to tell whether the server was missing credentials, had auth problems, or could not reach the model service.

## Validation
- `python3 -m unittest discover -s tests -v`
