### PR TITLE
Fix GUI startup regression in emoji toolbar

### DIFF
--- a/client/gui_client.py
+++ b/client/gui_client.py
@@ -139,8 +139,8 @@ class GUIChatClient:
         self.user_listbox = tk.Listbox(user_list_frame, width=18, height=18)
         self.user_listbox.pack(fill="y", expand=True)
 
-        emoji_frame = tk.Frame(self.root, padx=10, pady=(0, 6))
-        emoji_frame.pack(fill="x")
+        emoji_frame = tk.Frame(self.root, padx=10)
+        emoji_frame.pack(fill="x", pady=(0, 6))
         tk.Label(emoji_frame, text="Emoji").pack(side="left")
         for emoji in EMOJI_BUTTONS:
             tk.Button(


### PR DESCRIPTION
## Summary
- fix the emoji toolbar frame padding so Tkinter accepts the widget construction
- preserve the same vertical spacing by moving the tuple padding to pack()

## Testing
- python3 -m unittest discover -s tests -v
- python3 - <<'PY'
from client.gui_client import GUIChatClient
app = GUIChatClient()
print('gui init ok')
app.root.destroy()
PY