### PR TITLE
[codex] Implement README feature flows

### DIFF
--- a/bonus/ai_picture.py
+++ b/bonus/ai_picture.py
@@ -34,6 +34,7 @@ REQUEST_TIMEOUT = 60
 class AIPictureError(Exception):
     """Raised when AI picture generation fails."""
 
+
 def _build_image_prompt_with_llm(prompt: str) -> str:
     """Use the configured LLM to turn a user request into a concise image prompt."""
 
@@ -75,7 +76,8 @@ def _build_image_prompt_with_llm(prompt: str) -> str:
     try:
         content = response.json()["choices"][0]["message"]["content"].strip()
     except (ValueError, KeyError, IndexError, TypeError) as exc:
-        raise AIPictureError("Prompt model returned an unexpected response.") from exc
+        raise AIPictureError(
+            "Prompt model returned an unexpected response.") from exc
 
     if not content:
         raise AIPictureError("Prompt model returned an empty prompt.")
@@ -87,7 +89,7 @@ def parse_aipic_prompt(message: str) -> str | None:
     stripped = message.strip()
     if not stripped.lower().startswith(AIPIC_PREFIX):
         return None
-    prompt = stripped[len(AIPIC_PREFIX) :].strip()
+    prompt = stripped[len(AIPIC_PREFIX):].strip()
     return prompt or None
 
 
@@ -126,7 +128,8 @@ def generate_image(prompt: str, output_root: Path | None = None) -> str:
     root = output_root if output_root is not None else Path.cwd()
     output_dir = root / OUTPUT_DIR_NAME
     output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = _ensure_unique_path(output_dir, _slugify_filename(cleaned_prompt))
+    output_path = _ensure_unique_path(
+        output_dir, _slugify_filename(cleaned_prompt))
 
     try:
         response = requests.get(

--- a/client/client.py
+++ b/client/client.py
@@ -6,6 +6,8 @@ import argparse
 import socket
 import threading
 
+from bonus.sentiment import analyze_sentiment
+from chatbot.chatbot_manager import ChatbotManager
 from server.protocol import ProtocolError, create_message, decode_message, encode_message
 
 
@@ -39,9 +41,24 @@ def format_message(message: dict[str, str]) -> str:
     sender = message["sender"]
     timestamp = message["timestamp"]
     content = message["content"]
+    extra = message.get("extra", {})
 
     if msg_type == "chat":
         return f"[{timestamp}] {sender}: {content}"
+
+    if msg_type == "sentiment_result":
+        sentiment = ""
+        if isinstance(extra, dict):
+            sentiment = str(extra.get("sentiment", "")).strip()
+        if not sentiment:
+            sentiment = analyze_sentiment(content)
+        return f"[{timestamp}] {sender}: {content} [{sentiment}]"
+
+    if msg_type == "bot_response":
+        return f"[{timestamp}] Bot: {content}"
+
+    if msg_type in {"system", "error", "game_end", "summary_response", "keywords_response"}:
+        return f"[{timestamp}] {content}"
 
     return f"[{timestamp}] {msg_type.upper()} from {sender}: {content}"
 
@@ -51,6 +68,7 @@ def start_client(host: str, port: int, username: str) -> None:
 
     client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     client_socket.connect((host, port))
+    chatbot_manager = ChatbotManager()
 
     receiver = threading.Thread(target=receive_messages, args=(client_socket,), daemon=True)
     receiver.start()
@@ -64,7 +82,22 @@ def start_client(host: str, port: int, username: str) -> None:
             if user_input.strip().lower() == "/quit":
                 break
 
-            message = create_message("chat", username, user_input)
+            stripped_input = user_input.strip()
+            if chatbot_manager.is_personality_command(stripped_input):
+                personality_key = chatbot_manager.extract_personality_choice(stripped_input)
+                if not personality_key:
+                    print("Use /personality friendly, /personality funny, or /personality serious.")
+                    continue
+                message = create_message(
+                    "bot_request",
+                    username,
+                    stripped_input,
+                    extra={"action": "set_personality", "personality": personality_key},
+                )
+            elif chatbot_manager.is_bot_command(stripped_input):
+                message = create_message("bot_request", username, stripped_input)
+            else:
+                message = create_message("chat", username, user_input)
             client_socket.sendall(encode_message(message))
     except KeyboardInterrupt:
         pass

--- a/client/gui_client.py
+++ b/client/gui_client.py
@@ -206,6 +206,8 @@ class GUIChatClient:
         self.sync_personality_selection(username)
         try:
             self.send_login_message(username)
+            current_personality_key = self.chatbot_manager.get_personality_key(username)
+            self.send_personality_update_request(current_personality_key)
         except OSError:
             self.status_var.set("Status: Disconnected")
             self.show_local_system_message("Could not complete login with the server.")
@@ -255,7 +257,7 @@ class GUIChatClient:
         if self.chatbot_manager.is_personality_command(content):
             self.message_var.set("")
             self.message_entry.focus_set()
-            self.handle_personality_command(content)
+            self.request_personality_change(content)
             return
 
         if content == SUMMARY_COMMAND:
@@ -284,7 +286,10 @@ class GUIChatClient:
 
         try:
             rendered_content = self.expand_emoji_shortcodes(content)
-            message = create_message("chat", self.username_var.get().strip(), rendered_content)
+            if self.chatbot_manager.is_bot_command(rendered_content):
+                message = create_message("bot_request", self.username_var.get().strip(), rendered_content)
+            else:
+                message = create_message("chat", self.username_var.get().strip(), rendered_content)
             self.client_socket.sendall(encode_message(message))
             self.message_var.set("")
             self.message_entry.focus_set()
@@ -315,6 +320,24 @@ class GUIChatClient:
             )
             self.handle_disconnect()
 
+    def send_personality_update_request(self, personality_key: str) -> None:
+        """Send the selected bot personality to the server."""
+
+        if self.client_socket is None:
+            return
+
+        username = self.username_var.get().strip()
+        if not username:
+            return
+
+        message = create_message(
+            "bot_request",
+            username,
+            f"/personality {personality_key}",
+            extra={"action": "set_personality", "personality": personality_key},
+        )
+        self.client_socket.sendall(encode_message(message))
+
     def format_message(self, message: dict[str, object]) -> str:
         """Format protocol messages for the chat window."""
 
@@ -323,6 +346,16 @@ class GUIChatClient:
             if not content.strip():
                 return f"{message['sender']}: {content}\n"
             sentiment_label = analyze_sentiment(content)
+            return f"{message['sender']}: {content} [{sentiment_label}]\n"
+
+        if message["type"] == "sentiment_result":
+            content = self.expand_emoji_shortcodes(str(message.get("content", "")))
+            extra = message.get("extra", {})
+            sentiment_label = ""
+            if isinstance(extra, dict):
+                sentiment_label = str(extra.get("sentiment", "")).strip()
+            if not sentiment_label:
+                sentiment_label = analyze_sentiment(content)
             return f"{message['sender']}: {content} [{sentiment_label}]\n"
 
         if message["type"] == "bot_response":
@@ -340,6 +373,12 @@ class GUIChatClient:
 
         if message["type"] == "keywords_response":
             return f"Keywords: {message['content']}\n"
+
+        if message["type"] == "game_state":
+            return ""
+
+        if message["type"] == "game_end":
+            return f"System: {message['content']}\n"
 
         return f"{message['sender']}: {message['content']}\n"
 
@@ -566,7 +605,9 @@ class GUIChatClient:
 
         self.handle_game_message(message)
 
-        self.add_text(self.format_message(message))
+        rendered = self.format_message(message)
+        if rendered:
+            self.add_text(rendered)
 
     def handle_game_message(self, message: dict[str, object]) -> None:
         """Handle game protocol messages and drive game UI state."""
@@ -607,16 +648,18 @@ class GUIChatClient:
             if self.active_game_window is not None:
                 self.active_game_window.handle_server_message(message)
 
+        elif msg_type == "game_end":
+            if self.active_game_window is not None:
+                self.active_game_window.handle_server_message(message)
+
             winner = extra.get("winner")
             is_draw = bool(extra.get("is_draw", False))
-            is_game_over = bool(extra.get("is_game_over", False))
-            if is_game_over:
-                if winner:
-                    self.game_status_var.set(f"Game: Winner {winner}")
-                    self.add_text(f"System: Game result - {winner} wins\n")
-                elif is_draw:
-                    self.game_status_var.set("Game: Draw")
-                    self.add_text("System: Game result - Draw\n")
+            if winner:
+                self.game_status_var.set(f"Game: Winner {winner}")
+            elif is_draw:
+                self.game_status_var.set("Game: Draw")
+            else:
+                self.game_status_var.set("Game: Finished")
 
         elif msg_type == "error":
             text = self.friendly_server_error_message(str(message.get("content", "")))
@@ -673,12 +716,37 @@ class GUIChatClient:
         self.personality_var.set(self.chatbot_manager.get_personality_label(user_key))
         self.show_local_system_message(result_text)
 
+    def request_personality_change(self, command_text: str) -> None:
+        """Update local state and sync the selected bot personality to the server."""
+
+        user_key = self.get_chatbot_user_key()
+        personality_key = self.chatbot_manager.extract_personality_choice(command_text)
+        if not personality_key:
+            self.show_local_system_message(
+                "Use /personality friendly, /personality funny, or /personality serious."
+            )
+            return
+
+        self.chatbot_manager.set_personality(user_key, personality_key)
+        self.personality_var.set(self.chatbot_manager.get_personality_label(user_key))
+
+        if self.client_socket is None:
+            self.show_local_system_message(f"Bot personality set to {self.personality_var.get()}.")
+            return
+
+        try:
+            self.send_personality_update_request(personality_key)
+        except OSError:
+            self.status_var.set("Status: Disconnected")
+            self.show_local_system_message("Could not update bot personality because the server is unavailable.")
+            self.handle_disconnect()
+
     def on_personality_selected(self, selected_label: str) -> None:
         """Update the chatbot manager when the dropdown changes."""
 
         self.personality_var.set(selected_label)
-        self.sync_personality_selection()
-        self.show_local_system_message(f"Bot personality set to {selected_label}.")
+        personality_key = self.chatbot_manager.personality_key_from_label(selected_label)
+        self.request_personality_change(f"/personality {personality_key}")
 
     def close_window(self) -> None:
         """Close the socket first so the app exits cleanly."""

--- a/game/game_window.py
+++ b/game/game_window.py
@@ -151,6 +151,8 @@ class GameWindow:
             self._handle_game_state(message)
         elif msg_type == "game_start":
             self._handle_game_start(message)
+        elif msg_type == "game_end":
+            self._handle_game_end(message)
         elif msg_type == "error":
             self._handle_error(message)
 
@@ -202,6 +204,26 @@ class GameWindow:
         content = message.get("content", "Unknown error")
         self.root.after(0, lambda: self.result_var.set(f"Error: {content}"))
 
+    def _handle_game_end(self, message: dict) -> None:
+        """Handle the final game result message from the server."""
+
+        extra = message.get("extra", {})
+        winner = None
+        is_draw = False
+        if isinstance(extra, dict):
+            winner = extra.get("winner")
+            is_draw = bool(extra.get("is_draw", False))
+
+        if winner:
+            result_text = f"Result: {winner} wins"
+        elif is_draw:
+            result_text = "Result: Draw"
+        else:
+            result_text = str(message.get("content", "Game finished"))
+
+        self.last_game_over_text = result_text
+        self.root.after(0, lambda: self._apply_game_end(result_text))
+
     def _update_board_from_state(self, board: list, current_player: str, winner: str | None, is_draw: bool, is_game_over: bool) -> None:
         """Update the UI with the new board state from the server."""
 
@@ -221,6 +243,13 @@ class GameWindow:
             elif is_draw:
                 self.result_var.set("Result: Draw")
             self._disable_board()
+
+    def _apply_game_end(self, result_text: str) -> None:
+        """Apply the final game status to the local UI."""
+
+        self.status_var.set(result_text)
+        self.result_var.set(result_text)
+        self._disable_board()
 
     def reset_game(self) -> None:
         """Restart the game and clear the board."""

--- a/server/game_manager.py
+++ b/server/game_manager.py
@@ -104,7 +104,23 @@ class GameManager:
         with self.lock:
             room_id = self.player_in_game.pop(player_name, None)
             if room_id and room_id in self.rooms:
-                self.rooms.pop(room_id, None)
+                room = self.rooms.pop(room_id, None)
+                if room is not None:
+                    self.player_in_game.pop(room.x_player_name, None)
+                    if room.o_player_name:
+                        self.player_in_game.pop(room.o_player_name, None)
+
+    def finish_room(self, room_id: str) -> None:
+        """Remove a completed room so players can create or join a new game."""
+
+        with self.lock:
+            room = self.rooms.pop(room_id, None)
+            if room is None:
+                return
+
+            self.player_in_game.pop(room.x_player_name, None)
+            if room.o_player_name:
+                self.player_in_game.pop(room.o_player_name, None)
 
     def handle_move(self, room_id: str, player_name: str, row: int, col: int) -> tuple[bool, dict]:
         """Handle a player's move and return the game state."""

--- a/server/server.py
+++ b/server/server.py
@@ -15,6 +15,7 @@ from bonus.summary_keywords import (
     extract_keywords,
     generate_summary,
 )
+from bonus.sentiment import analyze_sentiment
 from chatbot.chatbot_client import (
     ChatBotAuthenticationError,
     ChatBotConfigurationError,
@@ -143,7 +144,7 @@ class ChatServer:
         if msg_type == "error":
             return
 
-        if msg_type in {"game_state", "game_end"}:
+        if msg_type in {"game_state", "game_end", "sentiment_result"}:
             return
 
         sender_name = self._normalize_name(message["sender"], source_socket)
@@ -173,6 +174,11 @@ class ChatServer:
             self._handle_game_create(source_socket, sender_name)
             return
 
+        if msg_type == "bot_request":
+            self._announce_join_if_needed(source_socket)
+            self._handle_bot_request(source_socket, sender_name, content, extra)
+            return
+
         if msg_type == "game_join":
             room_id = str(extra.get("room_id", "")).strip()
             self._handle_game_join(source_socket, sender_name, room_id)
@@ -189,10 +195,9 @@ class ChatServer:
         target = message["target"]
         if target == "all":
             message["sender"] = sender_name
-            self.broadcast(message)
-            self._record_group_message(message)
+            self._broadcast_public_chat(message)
 
-            if self._should_trigger_group_bot(message):
+            if self._should_trigger_group_bot(message["content"], sender_name):
                 thread = threading.Thread(
                     target=self._handle_group_bot_mention,
                     args=(sender_name, message["content"]),
@@ -335,18 +340,84 @@ class ChatServer:
             extra={"user_list": self.get_online_users()},
         )
 
-    def _should_trigger_group_bot(self, message: dict[str, str]) -> bool:
+    def _broadcast_public_chat(self, message: dict[str, object]) -> None:
+        """Broadcast one public chat message with a server-generated sentiment label."""
+
+        sender = str(message.get("sender", "")).strip()
+        content = str(message.get("content", ""))
+        target = str(message.get("target", "all")).strip() or "all"
+        extra = dict(message.get("extra", {})) if isinstance(message.get("extra", {}), dict) else {}
+
+        display_message = create_message(
+            "sentiment_result",
+            sender,
+            content,
+            target=target,
+            extra={**extra, "sentiment": analyze_sentiment(content)},
+        )
+        if "timestamp" in message:
+            display_message["timestamp"] = str(message["timestamp"])
+
+        self.broadcast(display_message)
+        self._record_group_message(
+            {
+                "type": "chat",
+                "sender": sender,
+                "target": target,
+                "content": content,
+                "timestamp": display_message["timestamp"],
+                "extra": extra,
+            }
+        )
+
+    def _should_trigger_group_bot(self, content: str, sender_name: str) -> bool:
         """Return True when a public chat message mentions the bot."""
 
-        if message.get("type") != "chat":
-            return False
-
-        sender = str(message.get("sender", "")).strip().lower()
+        sender = sender_name.strip().lower()
         if not sender or sender == "bot":
             return False
 
-        content = str(message.get("content", ""))
         return bool(content.strip() and self.bot_mention_pattern.search(content))
+
+    def _handle_bot_request(
+        self,
+        source_socket: socket.socket,
+        sender_name: str,
+        content: str,
+        extra: dict[str, object],
+    ) -> None:
+        """Handle chatbot prompt requests and personality updates."""
+
+        action = str(extra.get("action", "")).strip().lower()
+        if action == "set_personality":
+            personality_key = str(extra.get("personality", "")).strip().lower()
+            try:
+                label = self.chatbot_manager.set_personality(sender_name, personality_key)
+            except ValueError:
+                self.send_error(
+                    "Use /personality friendly, /personality funny, or /personality serious.",
+                    source_socket,
+                )
+                return
+
+            confirmation = create_message(
+                "system",
+                "System",
+                f"Bot personality set to {label}.",
+                target=sender_name,
+            )
+            self._safe_send_bytes(source_socket, encode_message(confirmation))
+            return
+
+        chat_message = create_message("chat", sender_name, content, target="all")
+        self._broadcast_public_chat(chat_message)
+
+        thread = threading.Thread(
+            target=self._handle_group_bot_mention,
+            args=(sender_name, content),
+            daemon=True,
+        )
+        thread.start()
 
     def _record_group_message(self, message: dict[str, str]) -> None:
         """Store a public message so bot prompts can use recent context.
@@ -636,6 +707,29 @@ class ChatServer:
         # Broadcast to both players
         self._safe_send_bytes(room.x_socket, encode_message(game_state_message))
         self._safe_send_bytes(room.o_socket, encode_message(game_state_message))
+
+        if result["is_game_over"]:
+            if result["winner"]:
+                result_text = f"Game result - {result['winner']} wins"
+            else:
+                result_text = "Game result - Draw"
+
+            game_end_message = create_message(
+                "game_end",
+                "Server",
+                result_text,
+                extra={
+                    "room_id": room_id,
+                    "board": result["board"],
+                    "winner": result["winner"],
+                    "is_draw": result["is_draw"],
+                    "x_player": room.x_player_name,
+                    "o_player": room.o_player_name,
+                },
+            )
+            self._safe_send_bytes(room.x_socket, encode_message(game_end_message))
+            self._safe_send_bytes(room.o_socket, encode_message(game_end_message))
+            self.game_manager.finish_room(room_id)
 
     def _normalize_name(self, requested_name: str, client_socket: socket.socket) -> str:
         """Use a readable guest name when the sender field is empty."""

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -6,6 +6,7 @@ import socket
 import unittest
 from unittest.mock import patch
 
+from bonus.sentiment import analyze_sentiment
 from chatbot.chatbot_client import (
     ChatBotAuthenticationError,
     ChatBotConfigurationError,
@@ -125,6 +126,130 @@ class ErrorHandlingTests(unittest.TestCase):
         self.assertEqual(error_message["type"], "error")
         self.assertEqual(error_message["content"], "Invalid move. It is not your turn.")
         self.assertIn("Invalid game move", "\n".join(move_logs.output))
+
+    def test_public_chat_is_broadcast_as_sentiment_result(self) -> None:
+        _alice_client, alice_file, alice_server = self._add_client("Alice")
+        _bob_client, bob_file, _bob_server = self._add_client("Bob")
+
+        self.server.route_message(
+            alice_server,
+            create_message("chat", "Alice", "I am very happy today!"),
+        )
+
+        alice_message = self._read_message(alice_file)
+        bob_message = self._read_message(bob_file)
+
+        self.assertEqual(alice_message["type"], "sentiment_result")
+        self.assertEqual(bob_message["type"], "sentiment_result")
+        self.assertEqual(alice_message["content"], "I am very happy today!")
+        self.assertEqual(alice_message["extra"]["sentiment"], analyze_sentiment("I am very happy today!"))
+
+    def test_bot_request_updates_server_personality(self) -> None:
+        _alice_client, alice_file, alice_server = self._add_client("Alice")
+
+        self.server.route_message(
+            alice_server,
+            create_message(
+                "bot_request",
+                "Alice",
+                "/personality serious",
+                extra={"action": "set_personality", "personality": "serious"},
+            ),
+        )
+
+        message = self._read_message(alice_file)
+        self.assertEqual(message["type"], "system")
+        self.assertEqual(message["content"], "Bot personality set to Serious Assistant.")
+        self.assertEqual(self.server.chatbot_manager.get_personality_key("Alice"), "serious")
+
+    def test_bot_request_broadcasts_prompt_and_bot_reply(self) -> None:
+        _alice_client, alice_file, alice_server = self._add_client("Alice")
+        _bob_client, bob_file, _bob_server = self._add_client("Bob")
+
+        with patch.object(self.server.chatbot_manager, "chat", return_value="Hello from Bot"):
+            self.server.route_message(
+                alice_server,
+                create_message("bot_request", "Alice", "@bot help me"),
+            )
+
+        alice_prompt = self._read_message(alice_file)
+        bob_prompt = self._read_message(bob_file)
+        alice_reply = self._read_message(alice_file)
+        bob_reply = self._read_message(bob_file)
+
+        self.assertEqual(alice_prompt["type"], "sentiment_result")
+        self.assertEqual(bob_prompt["type"], "sentiment_result")
+        self.assertEqual(alice_prompt["content"], "@bot help me")
+        self.assertEqual(alice_reply["type"], "bot_response")
+        self.assertEqual(bob_reply["type"], "bot_response")
+        self.assertEqual(alice_reply["content"], "Hello from Bot")
+
+    def test_game_end_message_is_sent_and_room_is_released(self) -> None:
+        _alice_client, alice_file, alice_server = self._add_client("Alice")
+        _bob_client, bob_file, bob_server = self._add_client("Bob")
+
+        self.server.route_message(alice_server, create_message("game_create", "Alice", "create room"))
+        create_response = self._read_message(alice_file)
+        room_id = str(create_response["extra"]["room_id"])
+
+        self.server.route_message(
+            bob_server,
+            create_message(
+                "game_join",
+                "Bob",
+                f"join {room_id}",
+                extra={"room_id": room_id},
+            ),
+        )
+        self._read_message(alice_file)
+        self._read_message(bob_file)
+
+        moves = (
+            (alice_server, alice_file, bob_file, 0, 0),
+            (bob_server, bob_file, alice_file, 1, 0),
+            (alice_server, alice_file, bob_file, 0, 1),
+            (bob_server, bob_file, alice_file, 1, 1),
+            (alice_server, alice_file, bob_file, 0, 2),
+        )
+        for player_server, own_file, other_file, row, col in moves[:-1]:
+            self.server.route_message(
+                player_server,
+                create_message(
+                    "game_move",
+                    "Alice" if player_server is alice_server else "Bob",
+                    "move",
+                    extra={"room_id": room_id, "row": row, "col": col},
+                ),
+            )
+            self._read_message(own_file)
+            self._read_message(other_file)
+
+        final_server, final_file, other_file, row, col = moves[-1]
+        self.server.route_message(
+            final_server,
+            create_message(
+                "game_move",
+                "Alice",
+                "move",
+                extra={"room_id": room_id, "row": row, "col": col},
+            ),
+        )
+
+        final_state_a = self._read_message(final_file)
+        final_state_b = self._read_message(other_file)
+        final_end_a = self._read_message(final_file)
+        final_end_b = self._read_message(other_file)
+
+        self.assertEqual(final_state_a["type"], "game_state")
+        self.assertEqual(final_state_b["type"], "game_state")
+        self.assertEqual(final_end_a["type"], "game_end")
+        self.assertEqual(final_end_b["type"], "game_end")
+        self.assertEqual(final_end_a["extra"]["winner"], "X")
+        self.assertIsNone(self.server.game_manager.get_room(room_id))
+
+        self.server.route_message(alice_server, create_message("game_create", "Alice", "create room"))
+        next_room_message = self._read_message(alice_file)
+        self.assertEqual(next_room_message["type"], "game_create")
 
     def test_chatbot_missing_config_returns_friendly_system_message(self) -> None:
         _alice_client, alice_file, _alice_server = self._add_client("Alice")


### PR DESCRIPTION
## What changed

This PR makes the README-described feature flows real end-to-end behavior instead of partial or placeholder protocol support.

- routes `@bot` through `bot_request` and returns real `bot_response` messages
- syncs `/personality` changes from clients to the server-side chatbot state
- emits `sentiment_result` for public chat so sentiment labels are part of the actual protocol flow
- emits and handles `game_end` so multiplayer Tic-Tac-Toe has a real completion message and room cleanup
- expands test coverage for bot requests, sentiment results, and full game completion handling

## Why

The README listed these features as supported, but parts of the implementation were either local-only or only present as protocol enum values without real message handling.

## Impact

Users now get consistent behavior across GUI and terminal clients, and the documented bot/game protocol flows are implemented for real.

## Validation

- `python3 -m pytest -q`
- end-to-end socket smoke tests for chat, summary, keywords, bot memory/personality, and Tic-Tac-Toe completion
- real AI validation for `@bot` and `/aipic:` with the configured endpoint
